### PR TITLE
Prevents comments in code blocks splitting files. Formatting changes to filenames.

### DIFF
--- a/split_md_05.py
+++ b/split_md_05.py
@@ -110,6 +110,8 @@ code_block = False
 for line in lines:
     if line.strip().startswith('```'): 
         code_block ^= True
+        if "```" in line.strip()[line.strip().startswith('```'):]:
+            code_block ^= True
 
     if line.strip().startswith(split_level) or code_block == True: #By default h3 and below will not be split into another file
         sect_text += line + "\n"

--- a/split_md_05.py
+++ b/split_md_05.py
@@ -51,6 +51,7 @@ def clean_file_name(fname):
     fname = fname.replace("|", "-")
     fname = fname.replace("—", "-")
     fname = fname.replace("_##.md", ".md")
+    fname = fname.replace("_#.md", ".md")
     if (no_spaces):
         fname = fname.replace(" ", "-")
 

--- a/split_md_05.py
+++ b/split_md_05.py
@@ -50,8 +50,10 @@ def clean_file_name(fname):
     fname = fname.replace("?", "-")
     fname = fname.replace("|", "-")
     fname = fname.replace("—", "-")
+    fname = fname.replace("_##.md", ".md")
     if (no_spaces):
         fname = fname.replace(" ", "-")
+
     return fname
 
 

--- a/split_md_05.py
+++ b/split_md_05.py
@@ -102,8 +102,8 @@ path_num = 1
 file_prefix = ""
 path_prefix = ""
 if num_files:
-    file_prefix = str(file_num).zfill(2) + " - "
-    path_prefix = str(path_num).zfill(2) + " - "
+    file_prefix = str(file_num).zfill(2) + "-"
+    path_prefix = str(path_num).zfill(2) + "-"
 
 subpath = path_prefix + "Front matter"
 fname = subpath + ".md"
@@ -121,7 +121,7 @@ for line in lines:
     elif line.strip().startswith("#"):  # - h1 and h2
         file_num += 1
         if num_files:
-            file_prefix = str(file_num).zfill(2) + " - "
+            file_prefix = str(file_num).zfill(2) + "-"
         if sect_text != "":
             md_combined += print_file(subpath, fname, sect_text)
         elif path_num == 1:
@@ -130,8 +130,8 @@ for line in lines:
             path_num += 1
             file_num = 1
             if num_files:
-                path_prefix = str(path_num).zfill(2) + " - "
-                file_prefix = str(file_num).zfill(2) + " - "
+                path_prefix = str(path_num).zfill(2) + "-"
+                file_prefix = str(file_num).zfill(2) + "-"
 
             subpath = path_prefix + re.sub(r"^(#+) ?(.+?) ?#*$", r"\2",
                                            line.strip())

--- a/split_md_05.py
+++ b/split_md_05.py
@@ -106,8 +106,12 @@ subpath = path_prefix + "Front matter"
 fname = subpath + ".md"
 
 sect_text = ""
+code_block = False
 for line in lines:
-    if line.strip().startswith(split_level): #By default h3 and below will not be split into another file
+    if line.strip().startswith('```'): 
+        code_block ^= True
+
+    if line.strip().startswith(split_level) or code_block == True: #By default h3 and below will not be split into another file
         sect_text += line + "\n"
     elif line.strip().startswith("#"):  # - h1 and h2
         file_num += 1


### PR DESCRIPTION
Fixes issue where a "#" character in a code block caused it to be seen as a separate h1 heading and be split out. 

Also makes small formatting changes to the filenames to remove extra spaces after the file number and redundant _# or _## at the end of the filename.